### PR TITLE
Matchfix

### DIFF
--- a/Lib/ApiSim.js
+++ b/Lib/ApiSim.js
@@ -221,10 +221,12 @@ class ApiSim {
             order = this.user.orders[orderIndex];
             if (order.side === 'buy') {
                 let size = order.size === undefined ? order.filled_size : order.size;
-                let funds = order.size === undefined ? parseFloat(order.specified_funds) :
+                let funds = order.specified_funds !== undefined ? parseFloat(order.specified_funds) :
                     parseFloat(order.size) * this.currentPrice * 1.003;
                 this.user.cryptoBalance += parseFloat(size);
-                this.user.fiatBalance -= funds
+                this.user.fiatBalance -= funds;
+                //no size on markt buys with funds until they are completed
+
             } else if (order.side === 'sell') {
                 let funds = order.size === undefined ? parseFloat(order.funds) :
                     parseFloat(order.size) * this.currentPrice * 0.997;
@@ -233,7 +235,7 @@ class ApiSim {
             messages.push(this.createMatch({
                 side: order.side,
                 taker_order_id: order.id,
-                size: order.size,
+                size: order.size !== undefined ? order.size : order.filled_size,
                 price: this.currentPrice,
                 product_id: order.product_id,
                 time: time

--- a/test/MarketOrderWithFunds.js
+++ b/test/MarketOrderWithFunds.js
@@ -36,6 +36,16 @@ describe("#ApiSim Market Orders With Funds", () => {
 
     describe("#fillOrder", () => {
         let time = "2018-12-06T01:46:01.162000Z";
+        it('produces a match with the proper variables', () => {
+            let Gdax = new ApiSim(2000, 2000);
+            Gdax.currentPrice = 20;
+            Gdax.buy(marketBuyPerams, (err, res, data) => {
+                let order = Gdax.user.orders[0];
+                let match = Gdax.fillOrder(data.id, data.size, time)[0];
+                assert.equal(match.size, order.filled_size);
+            });
+        });
+
         it('has the proper adjustmets made to the json object', () => {
             let Gdax = new ApiSim(2000, 2000);
             Gdax.currentPrice = 20;


### PR DESCRIPTION
fixed glitch that was causing matches to be broadcast that did not include the "size" param. This was causing various NaN errors down the line as the undefined size was attempted to be added to the candle objects.